### PR TITLE
Make gender enum public

### DIFF
--- a/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg01Mrz.java
+++ b/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg01Mrz.java
@@ -26,7 +26,7 @@ public final class Dnie3Dg01Mrz {
     private final Properties countryNames = CountryCodes.getCountryCodes();
 
     /** Sexo del titular del documento de identidad. */
-    private enum Gender {
+    public enum Gender {
 
     	/** Hombre. */
     	MALE("Hombre"), //$NON-NLS-1$


### PR DESCRIPTION
Hello,
The Gender enum is private, so I cannot use the method getSex() from Dnie3Dg01Mrz.

Example:
```
Dnie3Dg01Mrz dnie3Mrz = dnie3Card.getMrz();
dnie3Mrz.getSex();  // I cannot use the returned value.