### PR TITLE
Add province to identity parser and fix given name and surname

### DIFF
--- a/jmulticard-jse/src/test/java/es/gob/jmulticard/TestDnieLow.java
+++ b/jmulticard-jse/src/test/java/es/gob/jmulticard/TestDnieLow.java
@@ -182,9 +182,9 @@ public final class TestDnieLow {
 
 		final Dnie3Dg13Identity dnie3Dg13Identity = dnie3.getIdentity();
 
-		System.out.println("Name: " + dnie3Dg13Identity.getName()); //$NON-NLS-1$
-		System.out.println("Second name: " + dnie3Dg13Identity.getSecondSurname()); //$NON-NLS-1$
-		System.out.println("First name: " + dnie3Dg13Identity.getFirstSurname()); //$NON-NLS-1$
+		System.out.println("First surname: " + dnie3Dg13Identity.getFirstSurname()); //$NON-NLS-1$
+		System.out.println("Second surname: " + dnie3Dg13Identity.getSecondSurname()); //$NON-NLS-1$
+		System.out.println("Given name: " + dnie3Dg13Identity.getGivenName()); //$NON-NLS-1$
 		System.out.println("DNI number: " + dnie3Dg13Identity.getDniNumber()); //$NON-NLS-1$
 		System.out.println("Birth date: " + dnie3Dg13Identity.getBirthDate()); //$NON-NLS-1$
 		System.out.println("Nationality: " + dnie3Dg13Identity.getNationality()); //$NON-NLS-1$
@@ -196,6 +196,7 @@ public final class TestDnieLow {
 		System.out.println("Parent's names: " + dnie3Dg13Identity.getParentsNames()); //$NON-NLS-1$
 		System.out.println("Address: " + dnie3Dg13Identity.getAddress()); //$NON-NLS-1$
 		System.out.println("City: " + dnie3Dg13Identity.getCity()); //$NON-NLS-1$
+		System.out.println("Province: " + dnie3Dg13Identity.getProvince()); //$NON-NLS-1$
 		System.out.println("Country: " + dnie3Dg13Identity.getCountry()); //$NON-NLS-1$
 	}
 

--- a/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg13Identity.java
+++ b/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg13Identity.java
@@ -20,21 +20,21 @@ public final class Dnie3Dg13Identity {
 		this.parsedValues = new String(dg13RawData).split(CONTROL_CHARACTER_WORD.pattern());
 	}
 
-	/** Obtiene el nombre del titular.
-	 * @return Nombre del titular. */
-	public String getName() {
-		return this.parsedValues[1];
-	}
-
 	/** Obtiene el primer apellido del titular.
 	 * @return Primer apellido del titular. */
-	public String getSecondSurname() {
-		return this.parsedValues[2];
+	public String getFirstSurname() {
+		return this.parsedValues[1];
 	}
 
 	/** Obtiene el segundo apellido del titular.
 	 * @return Segundo apellido del titular. */
-	public String getFirstSurname() {
+	public String getSecondSurname() {
+		return this.parsedValues[2];
+	}
+
+	/** Obtiene el nombre del titular.
+	 * @return Nombre del titular. */
+	public String getGivenName() {
 		return this.parsedValues[3];
 	}
 
@@ -105,6 +105,12 @@ public final class Dnie3Dg13Identity {
 	public String getCity() {
 		return this.parsedValues[14];
 	}
+
+  /** Obtiene la provincia de residencia del titular.
+   * @return Provincia de residencia del titular. */
+  public String getProvince() {
+    return this.parsedValues[15];
+  }
 
 	/** Obtiene el pa&iacute;s de residencia del titular.
 	 * @return Pa&iacute;s de residencia del titular. */


### PR DESCRIPTION
I think the 15th index of the parsed values array contains the province, but I cannot test it.
The DNIe 3.0 card I have has a french address, with an empty string on the 15th index...
For the names, I made a confusion:
-the first and the second values are the "apellidos" on the DNIe 3.0 I have.
-the third is the "nombre". I think a least confusing name is "given name".
Tell me if you agree