### PR TITLE
Make parsing class non-final to allow unit testing

### DIFF
--- a/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg01Mrz.java
+++ b/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg01Mrz.java
@@ -7,7 +7,7 @@ import java.util.Date;
 import java.util.Properties;
 
 /** Zona ICAO MRZ del DNIe 3&#46;0.*/
-public final class Dnie3Dg01Mrz {
+public class Dnie3Dg01Mrz {
 
 	private final String mrzString;
 

--- a/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg13Identity.java
+++ b/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/Dnie3Dg13Identity.java
@@ -6,7 +6,7 @@ import java.util.Date;
 import java.util.regex.Pattern;
 
 /** Identidad del titular tal y como se encuentra en el fichero DG13 del DNIe 3. */
-public final class Dnie3Dg13Identity {
+public class Dnie3Dg13Identity {
 
 	/** This regEx matches on every pair (word) of control character (0x00-0x1F and
 	 * 0x7F-0x9F). */

--- a/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/DnieSubjectPrincipalParser.java
+++ b/jmulticard/src/main/java/es/gob/jmulticard/card/dnie/DnieSubjectPrincipalParser.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 
 /** Analizador del nombre X&#46;500 del titular de un DNIe.
  * @author Tom&aacute;s Garc&iacute;a-Mer&aacute;s. */
-public final class DnieSubjectPrincipalParser {
+public class DnieSubjectPrincipalParser {
 
 	private final String name;
 	private final String surname1;


### PR DESCRIPTION
Hello,
I cannot mock parsing class using Mockito because they are final.
This prevent my unit tests to work.
I think it is better to make these classes not final.
Thanks for your time !